### PR TITLE
add template files to package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,10 @@ setup(name='cg-django-uaa',
       license='Public Domain',
       url='https://github.com/18F/cg-django-uaa',
       package_dir={'uaa_client': 'uaa_client'},
+      package_data={
+        'uaa_client': ['fake_uaa_provider/*/*/*']
+      },
+      include_package_data=True,
       packages=find_packages(),
       install_requires=[
           'django>=1.8,<2',


### PR DESCRIPTION
I don't think the non-`.py` files are included unless they're specified in the `setup.py`, and this should fix it.