### PR TITLE
Add support for optional settings_local.py.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/_build/
 docs/_build_html/
 build/
 dist/
+example/example/settings_local.py

--- a/docs/developing.rst
+++ b/docs/developing.rst
@@ -41,6 +41,11 @@ To use it, run the following from the root of the repository::
 At this point you should be able to visit the locally-hosted project
 and login to fake cloud.gov as foo@example.org.
 
+If you'd like to modify any of the example app's settings, you can
+do so by creating an ``example/example/settings_local.py`` file;
+any settings defined there will override the ones in
+``example/example/settings.py``.
+
 Running tests
 ~~~~~~~~~~~~~
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -145,3 +145,8 @@ LOGGING = {
         }
     }
 }
+
+try:
+    from .settings_local import *
+except ImportError:
+    pass


### PR DESCRIPTION
This makes it easier to integrate the example app with the *real* cloud.gov, among other things.