### PR TITLE
Add UaaRefreshMiddleware

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ python:
  - "3.6"
  - "3.5"
 env:
- - DJANGO_VERSION=1.8.17
- - DJANGO_VERSION=1.10.5
+ - DJANGO_VERSION=1.8.18
+ - DJANGO_VERSION=1.10.7
 install:
  - pip install -r requirements-dev.txt
  - pip install -q Django==$DJANGO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ branches:
 python:
  - "3.6"
  - "3.5"
- - "3.4"
 env:
  - DJANGO_VERSION=1.8.17
  - DJANGO_VERSION=1.10.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Added
+
+* Added support for automatic refreshing of access tokens, which
+  is required for security. This involves adding
+  `uaa_client.middleware.UaaRefreshMiddleware` to your
+  middleware setting, after Django's session and authentication
+  middleware. For more details, see the documentation.
+
+* The example app now supports an optional `settings_local.py`,
+  so it's easy to e.g. connect to the real cloud.gov for manual
+  testing.
+
 ## 0.0.1 - 2017-02-02
 
 Initial release.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,8 +15,14 @@ Welcome to cg-django-uaa's documentation!
    developing
 
 This is a `cloud.gov <https://cloud.gov/>`_ UAA authentication backend
-for Django. It also includes a handy :ref:`fake cloud.gov <fakeauth>`
-that makes it easy to log in as any user during development.
+for Django. Features include:
+
+* A handy :ref:`fake cloud.gov <fakeauth>`
+  that makes it easy to log in as any user during development.
+
+* Transparent refreshing of short-lived access tokens, ensuring that
+  users are automatically logged out of the system soon after cloud.gov
+  says they are unauthorized.
 
 To get started, see the :doc:`quickstart`.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -53,6 +53,13 @@ to cloud.gov-based login.
 You'll also need to have ``django.contrib.auth`` and ``uaa_client`` in your
 ``INSTALLED_APPS`` setting.
 
+Finally, you will also need to add
+``uaa_client.middleware.UaaRefreshMiddleware`` to your ``MIDDLEWARE``
+setting (or ``MIDDLEWARE_CLASSES`` if you're on Django 1.8 or 1.9). It needs
+to be placed after 
+``django.contrib.sessions.middleware.SessionMiddleware`` and
+``django.contrib.auth.middleware.AuthenticationMiddleware``.
+
 Setting up URLs
 ~~~~~~~~~~~~~~~
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -58,7 +58,17 @@ Finally, you will also need to add
 setting (or ``MIDDLEWARE_CLASSES`` if you're on Django 1.8 or 1.9). It needs
 to be placed after 
 ``django.contrib.sessions.middleware.SessionMiddleware`` and
-``django.contrib.auth.middleware.AuthenticationMiddleware``.
+``django.contrib.auth.middleware.AuthenticationMiddleware``, e.g.:
+
+.. code-block:: python
+
+   MIDDLEWARE = [
+       # ...
+       'django.contrib.sessions.middleware.SessionMiddleware',
+       'django.contrib.auth.middleware.AuthenticationMiddleware',
+       'uaa_client.middleware.UaaRefreshMiddleware',
+       # ...
+   ]
 
 Setting up URLs
 ~~~~~~~~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -4,7 +4,7 @@ Quick start guide
 Prerequisites
 ~~~~~~~~~~~~~
 
-You will need Python 3.4 or above, and Django 1.8 or above.
+You will need Python 3.5 or above, and Django 1.8 or above.
 
 Installation
 ~~~~~~~~~~~~

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -56,9 +56,8 @@ You'll also need to have ``django.contrib.auth`` and ``uaa_client`` in your
 Finally, you will also need to add
 ``uaa_client.middleware.UaaRefreshMiddleware`` to your ``MIDDLEWARE``
 setting (or ``MIDDLEWARE_CLASSES`` if you're on Django 1.8 or 1.9). It needs
-to be placed after 
-``django.contrib.sessions.middleware.SessionMiddleware`` and
-``django.contrib.auth.middleware.AuthenticationMiddleware``, e.g.:
+to be placed after Django's session and authentication
+middleware, e.g.:
 
 .. code-block:: python
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -46,6 +46,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'uaa_client.middleware.UaaRefreshMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+
+warn_unused_ignores = True
+strict_optional = True
+check_untyped_defs = True
+follow_imports = silent
+ignore_missing_imports = True

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ coverage==4.3.4
 Sphinx==1.5.2
 sphinx-autobuild==0.6.0
 sphinx-rtd-theme==0.1.9
+mypy==0.501

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,9 @@ class UltraTestCommand(SimpleCommand):
             ['coverage', 'run', 'setup.py', 'test']
         )
         subprocess.check_call(
+            [sys.executable, '-m', 'mypy', 'uaa_client']
+        )
+        subprocess.check_call(
             ['flake8', 'uaa_client']
         )
         subprocess.check_call(

--- a/setup.py
+++ b/setup.py
@@ -61,15 +61,19 @@ class UltraTestCommand(SimpleCommand):
     description = "Run tests, code coverage, linting, etc."
 
     def run(self):
+        print("Running tests...")
         subprocess.check_call(
             ['coverage', 'run', 'setup.py', 'test']
         )
+        print("Running mypy...")
         subprocess.check_call(
             [sys.executable, '-m', 'mypy', 'uaa_client']
         )
+        print("Running flake8...")
         subprocess.check_call(
             ['flake8', 'uaa_client']
         )
+        print("Ensuring code coverage is at 100%...")
         subprocess.check_call(
             ['coverage', 'report', '-m']
         )

--- a/uaa_client/authentication.py
+++ b/uaa_client/authentication.py
@@ -42,7 +42,7 @@ def obtain_access_token(request, payload):
     return response['access_token']
 
 
-def update_access_token_with_refesh_token(request):
+def update_access_token_with_refresh_token(request):
     return obtain_access_token(request, {
         'grant_type': 'refresh_token',
         'refresh_token': request.session['uaa_refresh_token'],

--- a/uaa_client/authentication.py
+++ b/uaa_client/authentication.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from typing import Dict, Any, Optional
 import requests
 import jwt
 from django.core.exceptions import MultipleObjectsReturned
@@ -7,23 +8,25 @@ from django.core.urlresolvers import reverse
 from django.contrib.auth.models import User
 from django.contrib.auth.backends import ModelBackend
 from django.conf import settings
+from django.http.request import HttpRequest
 
 logger = logging.getLogger('uaa_client')
 
 
-def get_auth_url(request):
+def get_auth_url(request: HttpRequest) -> str:
     if settings.DEBUG and settings.UAA_AUTH_URL == 'fake:':
         return request.build_absolute_uri(reverse('uaa_client:fake_auth'))
     return settings.UAA_AUTH_URL
 
 
-def get_token_url(request):
+def get_token_url(request: HttpRequest) -> str:
     if settings.DEBUG and settings.UAA_TOKEN_URL == 'fake:':
         return request.build_absolute_uri(reverse('uaa_client:fake_token'))
     return settings.UAA_TOKEN_URL
 
 
-def obtain_access_token(request, payload):
+def obtain_access_token(request: HttpRequest,
+                        payload: Dict[str, Any]) -> Optional[str]:
     token_url = get_token_url(request)
     token_req = requests.post(token_url, data=payload)
     if token_req.status_code != 200:
@@ -42,7 +45,9 @@ def obtain_access_token(request, payload):
     return response['access_token']
 
 
-def update_access_token_with_refresh_token(request):
+def update_access_token_with_refresh_token(
+    request: HttpRequest
+) -> Optional[str]:
     return obtain_access_token(request, {
         'grant_type': 'refresh_token',
         'refresh_token': request.session['uaa_refresh_token'],
@@ -51,7 +56,8 @@ def update_access_token_with_refresh_token(request):
     })
 
 
-def exchange_code_for_access_token(request, code):
+def exchange_code_for_access_token(request: HttpRequest,
+                                   code: str) -> Optional[str]:
     redirect_uri = request.build_absolute_uri(reverse('uaa_client:callback'))
 
     return obtain_access_token(request, {

--- a/uaa_client/fake_uaa_provider.py
+++ b/uaa_client/fake_uaa_provider.py
@@ -10,7 +10,12 @@ from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
 
 
-TOKEN_EXPIRATION = timedelta(hours=1)
+TOKEN_EXPIRATION = timedelta(seconds=60)
+
+
+def uaa_refresh_exempt(func):
+    func.uaa_refresh_exempt = True
+    return func
 
 
 def expect(a, b):
@@ -39,17 +44,25 @@ def authorize(request):
     return HttpResponseRedirect('%s?%s' % (url, qs))
 
 
+@uaa_refresh_exempt
 @csrf_exempt
 @require_POST
 def access_token(request):
     client_id = settings.UAA_CLIENT_ID
 
-    email = request.POST['code']
+    grant_type = request.POST.get('grant_type')
+
+    if grant_type == 'authorization_code':
+        email = request.POST['code']
+        expect(request.POST.get('response_type'), 'token')
+    elif grant_type == 'refresh_token':
+        preamble, email = request.POST['refresh_token'].split(':')
+        expect(preamble, 'fake_oauth2_refresh_token')
+    else:
+        raise Exception("Invalid grant_type: %s" % grant_type)
 
     expect(request.POST.get('client_id'), client_id)
     expect(request.POST.get('client_secret'), settings.UAA_CLIENT_SECRET)
-    expect(request.POST.get('grant_type'), 'authorization_code')
-    expect(request.POST.get('response_type'), 'token')
 
     res = HttpResponse()
     res['content-type'] = 'application/json'
@@ -95,7 +108,7 @@ def access_token(request):
         'access_token': access_token.decode('ascii'),
         'expires_in': int(TOKEN_EXPIRATION.total_seconds()),
         'jti': 'fake_jti',
-        'refresh_token': 'fake_oauth2_refresh_token',
+        'refresh_token': 'fake_oauth2_refresh_token:%s' % email,
         'scope': 'openid',
         'token_type': 'bearer'
     })

--- a/uaa_client/fake_uaa_provider.py
+++ b/uaa_client/fake_uaa_provider.py
@@ -11,12 +11,10 @@ from django.http import (HttpResponse, HttpResponseBadRequest,
                          HttpResponseRedirect)
 
 
+from .middleware import uaa_refresh_exempt
+
+
 TOKEN_EXPIRATION = timedelta(seconds=60)
-
-
-def uaa_refresh_exempt(func):
-    func.uaa_refresh_exempt = True
-    return func
 
 
 def expect(a, b):

--- a/uaa_client/fake_uaa_provider.py
+++ b/uaa_client/fake_uaa_provider.py
@@ -7,7 +7,8 @@ from django.core.urlresolvers import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST, require_GET
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import (HttpResponse, HttpResponseBadRequest,
+                         HttpResponseRedirect)
 
 
 TOKEN_EXPIRATION = timedelta(seconds=60)
@@ -59,7 +60,7 @@ def access_token(request):
         preamble, email = request.POST['refresh_token'].split(':')
         expect(preamble, 'fake_oauth2_refresh_token')
     else:
-        raise Exception("Invalid grant_type: %s" % grant_type)
+        return HttpResponseBadRequest("Invalid grant_type: %s" % grant_type)
 
     expect(request.POST.get('client_id'), client_id)
     expect(request.POST.get('client_secret'), settings.UAA_CLIENT_SECRET)

--- a/uaa_client/middleware.py
+++ b/uaa_client/middleware.py
@@ -31,5 +31,5 @@ class UaaRefreshMiddleware(MiddlewareMixin):
                 logout(request)
             else:
                 logger.info(
-                    'Refreshing token for {} succeded.'.format(username)
+                    'Refreshing token for {} succeeded.'.format(username)
                 )

--- a/uaa_client/middleware.py
+++ b/uaa_client/middleware.py
@@ -1,0 +1,34 @@
+import logging
+import time
+from django.contrib.auth import logout
+
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
+
+from .authentication import update_access_token_with_refesh_token
+
+
+logger = logging.getLogger('uaa_client')
+
+
+class UaaRefreshMiddleware(MiddlewareMixin):
+    def process_request(self, request):
+        should_refresh = (
+            request.user.is_authenticated() and
+            'uaa_expiry' in request.session and
+            time.time() > request.session['uaa_expiry']
+        )
+
+        if should_refresh:
+            username = request.user.username
+            if update_access_token_with_refesh_token(request) is None:
+                logger.info(
+                    'Refreshing token for {} failed.'.format(username)
+                )
+                logout(request)
+            else:
+                logger.info(
+                    'Refreshing token for {} succeded.'.format(username)
+                )

--- a/uaa_client/middleware.py
+++ b/uaa_client/middleware.py
@@ -3,9 +3,9 @@ import time
 from django.contrib.auth import logout
 
 try:
-    from django.utils.deprecation import MiddlewareMixin
-except ImportError:
-    MiddlewareMixin = object
+    from django.utils.deprecation import MiddlewareMixin  # pragma: no cover
+except ImportError:  # pragma: no cover
+    MiddlewareMixin = object  # pragma: no cover
 
 from .authentication import update_access_token_with_refresh_token
 
@@ -13,7 +13,24 @@ from .authentication import update_access_token_with_refresh_token
 logger = logging.getLogger('uaa_client')
 
 
+def uaa_refresh_exempt(func):
+    func.uaa_refresh_exempt = True
+    return func
+
+
 class UaaRefreshMiddleware(MiddlewareMixin):
+    def _refresh(self, request):
+        username = request.user.username
+        if update_access_token_with_refresh_token(request) is None:
+            logger.info(
+                'Refreshing token for {} failed.'.format(username)
+            )
+            logout(request)
+        else:
+            logger.info(
+                'Refreshing token for {} succeeded.'.format(username)
+            )
+
     def process_view(self, request, view_func, view_args, view_kwargs):
         should_refresh = (
             request.user.is_authenticated() and
@@ -23,13 +40,4 @@ class UaaRefreshMiddleware(MiddlewareMixin):
         )
 
         if should_refresh:
-            username = request.user.username
-            if update_access_token_with_refresh_token(request) is None:
-                logger.info(
-                    'Refreshing token for {} failed.'.format(username)
-                )
-                logout(request)
-            else:
-                logger.info(
-                    'Refreshing token for {} succeeded.'.format(username)
-                )
+            self._refresh(request)

--- a/uaa_client/middleware.py
+++ b/uaa_client/middleware.py
@@ -14,11 +14,12 @@ logger = logging.getLogger('uaa_client')
 
 
 class UaaRefreshMiddleware(MiddlewareMixin):
-    def process_request(self, request):
+    def process_view(self, request, view_func, view_args, view_kwargs):
         should_refresh = (
             request.user.is_authenticated() and
             'uaa_expiry' in request.session and
-            time.time() > request.session['uaa_expiry']
+            time.time() > request.session['uaa_expiry'] and
+            not getattr(view_func, 'uaa_refresh_exempt', False)
         )
 
         if should_refresh:

--- a/uaa_client/middleware.py
+++ b/uaa_client/middleware.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     MiddlewareMixin = object
 
-from .authentication import update_access_token_with_refesh_token
+from .authentication import update_access_token_with_refresh_token
 
 
 logger = logging.getLogger('uaa_client')
@@ -24,7 +24,7 @@ class UaaRefreshMiddleware(MiddlewareMixin):
 
         if should_refresh:
             username = request.user.username
-            if update_access_token_with_refesh_token(request) is None:
+            if update_access_token_with_refresh_token(request) is None:
                 logger.info(
                     'Refreshing token for {} failed.'.format(username)
                 )

--- a/uaa_client/tests/test_authentication.py
+++ b/uaa_client/tests/test_authentication.py
@@ -1,6 +1,7 @@
 from unittest import mock
 import json
 import urllib.parse
+from typing import Dict, Any  # NOQA
 import jwt
 from django.test import TestCase, RequestFactory
 from django.test.utils import override_settings
@@ -192,7 +193,7 @@ class AuthenticationTests(TestCase):
 
         req = mock.MagicMock()
         req.build_absolute_uri.return_value = 'https://redirect_uri'
-        session = {}
+        session = {}  # type: Dict[str, Any]
         req.session.__setitem__.side_effect = session.__setitem__
 
         with httmock.HTTMock(mock_200_response):

--- a/uaa_client/tests/test_middleware.py
+++ b/uaa_client/tests/test_middleware.py
@@ -1,0 +1,68 @@
+from unittest import mock
+from django.test import TestCase
+
+from .. import middleware
+from ..middleware import UaaRefreshMiddleware, uaa_refresh_exempt
+
+
+def noop():
+    pass
+
+
+class FakeUser:
+    def __init__(self, is_authenticated):
+        self.username = 'foo'
+        self._is_authenticated = is_authenticated
+
+    def is_authenticated(self):
+        return self._is_authenticated
+
+
+class FakeRequest:
+    def __init__(self, is_authenticated=True, session=None):
+        self.user = FakeUser(is_authenticated)
+        self.session = session or {}
+
+
+class MiddlewareTests(TestCase):
+    def assertNoRefresh(self, request, view_func=noop, time=0):
+        mw = UaaRefreshMiddleware()
+
+        with mock.patch('time.time', return_value=time):
+            with mock.patch.object(mw, '_refresh') as m:
+                mw.process_view(request, view_func, [], {})
+                m.assert_not_called()
+
+    def test_no_refresh_if_unauthenticated(self):
+        self.assertNoRefresh(FakeRequest(is_authenticated=False))
+
+    def test_no_refresh_if_no_uaa_expiry(self):
+        self.assertNoRefresh(FakeRequest())
+
+    def test_no_refresh_if_token_not_expired(self):
+        self.assertNoRefresh(FakeRequest(
+            session={'uaa_expiry': 150}
+        ), time=100)
+
+    def test_no_refresh_if_view_func_is_exempt(self):
+        self.assertNoRefresh(FakeRequest(
+            session={'uaa_expiry': 150},
+        ), time=200, view_func=uaa_refresh_exempt(noop))
+
+    @mock.patch.object(middleware, 'logout')
+    @mock.patch.object(middleware, 'update_access_token_with_refresh_token')
+    def test_logout_when_refresh_fails(self, refresh, logout):
+        refresh.return_value = None
+        req = FakeRequest(session={'uaa_expiry': 150})
+        with mock.patch('time.time', return_value=200):
+            UaaRefreshMiddleware().process_view(req, noop, [], {})
+            logout.assert_called_once_with(req)
+
+    @mock.patch.object(middleware, 'logout')
+    @mock.patch.object(middleware, 'update_access_token_with_refresh_token')
+    def test_no_logout_when_refresh_succeeds(self, refresh, logout):
+        refresh.return_value = 'I am a fake access token'
+        req = FakeRequest(session={'uaa_expiry': 150})
+        with mock.patch('time.time', return_value=200):
+            UaaRefreshMiddleware().process_view(req, noop, [], {})
+            logout.assert_not_called()


### PR DESCRIPTION
This is an attempt to fix #22 by adding a new `UaaRefreshMiddleware` that checks to see if the user's access token has expired, and, if so, attempts to renew it using a [refresh request](http://openid.net/specs/openid-connect-core-1_0.html#RefreshTokens).  If that fails, then the user is logged out.

## Notes

* Django session expiry is no longer defined based on the access token expiry because I think it's important for the Django app to be in control of session expiry as much as possible without violating compliance requirements. For example, even if cloud.gov eventually needs to change its access token lifetime to just one minute, it'd be quite unfortunate if we forcibly expired user sessions after just one minute! So instead, we let the Django app dictate how long it'd like sessions to last, and we only forcibly logout a user if *both* their access token has expired *and* we were unable to renew it.

  This approach is useful because refresh tokens are almost guaranteed to have a longer lifetime than access tokens--for example, at the time of this writing, access tokens have a lifetime of 10-15 minutes, but refresh tokens have a lifetime of 24 hours.

* My one concern with this middleware approach is that if multiple requests are made by a user's browser, e.g. because dynamically-generated static assets are referenced by a page, or because a page makes multiple simultaneous API calls to a self-hosted API, then this middleware will be triggered multiple times. The good news is that I found in practice that cloud.gov UAA is OK with this: using a refresh token once doesn't render it invalid for subsequent uses. The bad news is that we'd still be making multiple identical requests to refresh the same access token, which isn't terribly efficient.

  I'm not sure if there are any decent ways around this that don't inflict additional burdens on the client Django app.  For instance, another possibility might be to make a scheduled task that iterates through all active sessions and expires them if cloud.gov thinks their related access tokens shouldn't be renewed--but this would require the client to have a task scheduler running.

## To do

- [x] Documentation
- [x] Tests for `middleware.py`
- [x] It might be useful to modify the fake cloud.gov endpoints to support token renewal. We might even want these endpoints to issue _really_ short-lived access-tokens, e.g. ones with 1 minute lifespans, to ensure that the renewal code is exercised a lot during development.
