### PR TITLE
include requirements-tests.txt in distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include README.rst
 include LICENSE.md
+include requirements-tests.txt
 recursive-include docs *
 recursive-include uaa_client/tests/templates *
 recursive-include uaa_client/static *


### PR DESCRIPTION
It looks like `requirements-tests.txt` is required by `setup.py`, and its absence is causing installation/upgrade to fail. It looks like the line referencing it isn't new, so I'm not sure whether this is actually a solution or not.