### PR TITLE
Tweak and document user auto-creation policy

### DIFF
--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -6,4 +6,4 @@ Authentication backends
 .. currentmodule:: uaa_client.authentication
 
 .. autoclass:: UaaBackend
-   :members: get_user_by_email
+   :members: get_user_by_email, should_create_user_for_email, create_user_with_email

--- a/uaa_client/tests/test_authentication.py
+++ b/uaa_client/tests/test_authentication.py
@@ -219,7 +219,7 @@ class AuthenticationTests(TestCase):
     def test_get_user_by_email_returns_none_when_user_does_not_exist(self, m):
         self.assertEqual(get_user_by_email('foo@example.org'), None)
         m.assert_called_with('User with email foo@example.org does not exist'
-                             ' and is not from an approved domain')
+                             ' and is not approved for auto-creation')
 
     @mock.patch('uaa_client.authentication.logger.warning')
     def test_get_user_by_email_returns_none_when_many_users_exist(self, m):


### PR DESCRIPTION
@stvnrlly this is a PR against your #31 that slightly refactors things and ensures the documentation for the new methods shows up in the sphinx docs.

In particular, it changes `get_user_by_email` from a `staticmethod` to a `classmethod`. This is important because it's now calling other sub-methods, all of which we want to make overrideable.  As a `classmethod`, this method can call sub-methods off `cls`, which allows subclasses that override those sub-methods to "just work".  In contrast, as a `staticmethod` we have to hard-code `UaaBackend` when calling sub-methods, which would mean that any subclasses overriding those sub-methods would *also* have to trivially override `get_user_by_email` to call their subclass specifically, which is really annoying.
