### PR TITLE
Add AppConfig and remember earliest DEBUG setting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ python:
 env:
  - DJANGO_VERSION=1.8.18
  - DJANGO_VERSION=1.10.7
+ - DJANGO_VERSION=1.11.2
 install:
  - pip install -r requirements-dev.txt
  - pip install -q Django==$DJANGO_VERSION

--- a/uaa_client/__init__.py
+++ b/uaa_client/__init__.py
@@ -1,1 +1,3 @@
 VERSION = '1.0.1'
+
+default_app_config = 'uaa_client.apps.UaaClientConfig'

--- a/uaa_client/apps.py
+++ b/uaa_client/apps.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig
+
+
+class UaaClientConfig(AppConfig):
+    name = 'uaa_client'
+    verbose_name = 'UAA Client'
+
+    def ready(self):
+        from . import configuration
+
+        configuration.validate_configuration()

--- a/uaa_client/configuration.py
+++ b/uaa_client/configuration.py
@@ -7,7 +7,15 @@ from django.http import HttpResponseNotFound
 from .authentication import UaaBackend
 
 
-def validate_configuration():
+# To determine whether we're running tests, we're going to remember the
+# earliest value of settings.DEBUG at the time that our app was initialized.
+# For more details on why this is important, see:
+#
+# https://github.com/18F/cg-django-uaa/issues/18
+earliest_debug_setting = settings.DEBUG
+
+
+def validate_configuration(use_earliest_debug_setting=True):
     for setting in ['UAA_CLIENT_ID', 'UAA_CLIENT_SECRET',
                     'UAA_AUTH_URL', 'UAA_TOKEN_URL']:
         val = getattr(settings, setting, None)
@@ -27,7 +35,11 @@ def validate_configuration():
             'must also be set to "fake:"'
         )
 
-    if not settings.DEBUG:
+    debug = settings.DEBUG
+    if use_earliest_debug_setting:
+        debug = earliest_debug_setting
+
+    if not debug:
         if not (settings.UAA_AUTH_URL.startswith('https://') and
                 settings.UAA_TOKEN_URL.startswith('https://')):
             raise ImproperlyConfigured(

--- a/uaa_client/tests/test_configuration.py
+++ b/uaa_client/tests/test_configuration.py
@@ -1,7 +1,11 @@
 from django.test import SimpleTestCase, override_settings
 from django.core.exceptions import ImproperlyConfigured
 
-from ..configuration import validate_configuration
+from .. import configuration
+
+
+def validate_configuration():
+    configuration.validate_configuration(use_earliest_debug_setting=False)
 
 
 class ConfigurationTests(SimpleTestCase):

--- a/uaa_client/tests/test_example_app.py
+++ b/uaa_client/tests/test_example_app.py
@@ -1,0 +1,21 @@
+import sys
+import subprocess
+from pathlib import Path
+from unittest import TestCase
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent.parent
+EXAMPLE_APP_DIR = ROOT_DIR / 'example'
+
+
+class ExampleAppTests(TestCase):
+    def test_example_app_tests_work(self):
+        # This is partly a regression test for the following issue:
+        #
+        # https://github.com/18F/cg-django-uaa/issues/18
+
+        subprocess.check_output(
+            [sys.executable, 'manage.py', 'test'],
+            stderr=subprocess.STDOUT,
+            cwd=str(EXAMPLE_APP_DIR)
+        )


### PR DESCRIPTION
This fixes #18 and #21 by adding a default `AppConfig` that remembers the earliest-possible value of `settings.DEBUG` and uses it whenever `validate_configuration()` is called, unless overridden by an argument (which is only really used to test `validate_configuration()` itself).

Since the setting of `DEBUG` only changes throughout the process lifetime when running tests (famous last words), this *should* fix #18 without us having to add special "test suite detection logic" for all the different testing frameworks out there.
